### PR TITLE
Switch substitute store to exclusive scope cache

### DIFF
--- a/lib/event_store/entity_store/entity_store.rb
+++ b/lib/event_store/entity_store/entity_store.rb
@@ -144,7 +144,7 @@ module EventStore
 
     module Substitute
       def self.build
-        store = Store.build refresh: :none
+        store = Store.build refresh: :none, scope: :exclusive
         store.configure_dependencies
         store
       end


### PR DESCRIPTION
This is important for tests that use store substitutes. Without this
commit, each time a substitute store is constructed, the same actual
cache is used. So if one test inserts an object into the cache for a
given store scoped to that test, all other stores in all other tests
will still use that same cache.